### PR TITLE
Data ingress by API; remove /dev/ttyUSB0 in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,8 +33,6 @@ services:
     ports:
       - 7777:80
       - 7779:443
-    devices:
-      - /dev/ttyUSB0:/dev/ttyUSB0
 
 #volumes:
 #   dsmrdb:


### PR DESCRIPTION
Hello,

I am using my Pi at home to feed my DSMR docker hosted on my VPS. Is it possible to maintain an extra file that has no devices reference?

Thanks!

Best regards,

Jurgen Brunink