### PR TITLE
Data ingress by API; remove /dev/ttyUSB0 in docker-compose.yaml

### DIFF
--- a/docker-compose-nodevices.yaml
+++ b/docker-compose-nodevices.yaml
@@ -1,0 +1,40 @@
+version: '3.6'
+
+services:
+  dsmrdb:
+    image: postgres
+    container_name: dsmrdb
+    volumes:
+      - ./dsmrdb:/var/lib/postgresql/data
+      - ./dsmrdb_backups:/dsmr/backups
+    restart: always
+    environment:
+      - POSTGRES_USER=dsmrreader
+      - POSTGRES_PASSWORD=dsmrreader
+      - POSTGRES_DB=dsmrreader
+
+  dsmr:
+#    build: .
+    image: xirixiz/dsmr-reader-docker
+    container_name: dsmr
+    depends_on:
+      - dsmrdb
+    cap_add:
+      - NET_ADMIN    
+    links:
+      - dsmrdb
+    restart: always
+    environment:
+      - DB_HOST=dsmrdb
+      - DSMR_USER=admin
+      - DSMR_EMAIL=root@localhost
+      - DSMR_PASSWORD=admin
+      - VIRTUAL_HOST=localhost
+    ports:
+      - 7777:80
+      - 7779:443
+
+#volumes:
+#   dsmrdb:
+#   dsmrdb_backups:
+


### PR DESCRIPTION
Hello,

I am using my Pi at home to feed my DSMR docker hosted on my VPS. Is it possible to maintain an extra file that has no devices reference?

Thanks!

Best regards,

Jurgen Brunink