### PR TITLE
Use postgres alpine image for compatability with RPi and to reduce the size used on disk for python.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   dsmrdb:
-    image: postgres
+    image: postgres:10.5-alpine
     container_name: dsmrdb
     volumes:
       - ./dsmrdb:/var/lib/postgresql/data


### PR DESCRIPTION
Use postgres alpine image for compatability with RPi and to reduce the size used on disk for python.