### PR TITLE
[WIP] adding basic http authentication capabilities

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -29,6 +29,7 @@ RUN ["/usr/bin/qemu-__QEMU_ARCH__-static", "/bin/sh", "-c", \
       bash \
       curl \
       nginx \
+      openssl \
       postgresql-client \
       tzdata \
       supervisor"]


### PR DESCRIPTION
**Work in progress**, not done yet. Need to test this fully yet. 
Any preliminary feedback would be appreciated. 

Contains the following: 
- if/else check to enable http authentication sequence.
- Check if the needed environment variables are set.
- Generates htpasswd file
- Enables configuration inside nginx
- Test nginx config modification

Todo:
- Add docker secrets compatibility: using docker swarm you can mount secrets on `/run/secrets/<secret_name>`, this way you can add the password without having it on your filesystem. 