### PR TITLE
Simplify qemu cross compilation

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,6 +1,5 @@
 FROM __BASEIMAGE_ARCH__/python:alpine
 
-ENV QEMU_EXECVE 1
 COPY ./tmp/qemu/qemu-__QEMU_ARCH__-static /usr/bin/
 COPY ./tmp/dsmr/ /dsmr
 
@@ -24,37 +23,32 @@ ENV SD_AUTORESTART_BACKEND true
 ENV SD_AUTOSTART_MQTT true
 ENV SD_AUTORESTART_MQTT true
 
-RUN ["/usr/bin/qemu-__QEMU_ARCH__-static", "/bin/sh", "-c", \
-     "apk --update add --no-cache \
+RUN apk --update add --no-cache \
       bash \
       curl \
       nginx \
       openssl \
       postgresql-client \
       tzdata \
-      supervisor"]
+      supervisor
 
-RUN ["/usr/bin/qemu-__QEMU_ARCH__-static", "/bin/sh", "-c", \
-     "cp /dsmr/dsmrreader/provisioning/django/postgresql.py /dsmr/dsmrreader/settings.py"]
+RUN cp /dsmr/dsmrreader/provisioning/django/postgresql.py /dsmr/dsmrreader/settings.py
 
-RUN ["/usr/bin/qemu-__QEMU_ARCH__-static", "/bin/sh", "-c", \
-     "apk add --virtual .build-deps gcc musl-dev postgresql-dev && \
+RUN apk add --virtual .build-deps gcc musl-dev postgresql-dev && \
       pip3 install -r /dsmr/dsmrreader/provisioning/requirements/base.txt --no-cache-dir && \
       pip3 install -r /dsmr/dsmrreader/provisioning/requirements/postgresql.txt --no-cache-dir && \
       apk --purge del .build-deps && \
-      rm -rf /tmp/*"]
+      rm -rf /tmp/*
 
-RUN ["/usr/bin/qemu-__QEMU_ARCH__-static", "/bin/sh", "-c", \
-     "mkdir -p /run/nginx/ && \
+RUN mkdir -p /run/nginx/ && \
       ln -sf /dev/stdout /var/log/nginx/access.log && \
       ln -sf /dev/stderr /var/log/nginx/error.log && \
       rm -f /etc/nginx/conf.d/default.conf && \
       mkdir -p /var/www/dsmrreader/static && \
-      cp /dsmr/dsmrreader/provisioning/nginx/dsmr-webinterface /etc/nginx/conf.d/dsmr-webinterface.conf"]
+      cp /dsmr/dsmrreader/provisioning/nginx/dsmr-webinterface /etc/nginx/conf.d/dsmr-webinterface.conf
 
 COPY ./app/run.sh /run.sh
-RUN ["/usr/bin/qemu-__QEMU_ARCH__-static", "/bin/sh", "-c", \
-     "chmod u+x /run.sh"]
+RUN chmod u+x /run.sh
 
 COPY ./app/supervisord.ini /etc/supervisor.d/supervisord.ini
 

--- a/update_images.sh
+++ b/update_images.sh
@@ -119,7 +119,7 @@ function _build_docker_files() {
   _info "Building Docker images..."
   for docker_arch in ${ARCH_ARR}; do
     _info "Building Docker images for: ${docker_arch}, release ${dsmr_release}."
-    docker build --rm -f Dockerfile."${docker_arch}" -t "${DOCKER_HUB_REPO}":"${docker_arch}"-latest .
+    docker build -f Dockerfile."${docker_arch}" -t "${DOCKER_HUB_REPO}":"${docker_arch}"-latest .
     docker tag "${DOCKER_HUB_REPO}":"${docker_arch}"-latest "${DOCKER_HUB_REPO}":test-"${docker_arch}"-latest
     docker tag "${DOCKER_HUB_REPO}":"${docker_arch}"-latest "${DOCKER_HUB_REPO}":"${docker_arch}-${dsmr_release}"
     if [[ "${docker_arch}" == "amd64" ]]; then


### PR DESCRIPTION
Ref #93
Remove unnecessary `/usr/bin/qemu-${arch}-static` prefixes from Dockerfile
Expect the host to have `qemu-user-static` with kernel `binfmt` support.

This works for a local `arm32v6` build.
Build on azure-pipelines (local fork) running ([link](https://dev.azure.com/tomkooij/tom_kooij/_build?definitionId=1&_a=summary))
EDIT: Build OK. [docker hub](https://hub.docker.com/r/tomkooij/dsmr-reader-docker/tags) pulled and running on my raspberry pi.