### PR TITLE
Fix docker-compose example

### DIFF
--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -3,7 +3,6 @@ version: '3.6'
 services:
   dsmrdb:
     image: postgres:12-alpine
-    container_name: dsmrdb
     restart: always
     volumes:
       - /etc/localtime:/etc/localtime:ro
@@ -19,7 +18,6 @@ services:
   dsmr:
 #    build: .
     image: xirixiz/dsmr-reader-docker:latest
-    container_name: dsmr
     depends_on:
       - dsmrdb
     cap_add:

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ./dsmrdb:/var/lib/postgresql/data
-      - ./dsmrdb/backups:/dsmrdb/backups
+      - ./dsmrdb_backups:/dsmrdb/backups
     environment:
       - TZ=Europe/Amsterdam
       - PG_TZ=Europe/Amsterdam
@@ -23,7 +23,7 @@ services:
     depends_on:
       - dsmrdb
     cap_add:
-      - NET_ADMIN    
+      - NET_ADMIN
     links:
       - dsmrdb
     restart: always
@@ -42,4 +42,3 @@ services:
 #volumes:
 #   dsmrdb:
 #   dsmrdb_backups:
-

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -22,8 +22,6 @@ services:
       - dsmrdb
     cap_add:
       - NET_ADMIN
-    links:
-      - dsmrdb
     restart: always
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
The Postgres container would not start up because the `dsmrdb` volume contained a `backups` folder. Also some other cleanup.