### PR TITLE
deprecate arm32

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 ##### STABLE releases. Download and install DSMR Reader release on container startup (See DSMR_RELEASE variable for more information)
 ```
-latest-<version>-arm32v7
 latest-<version>-arm64v8
 latest-<version>-amd64
 ```


### PR DESCRIPTION
- arm32 deprecated
- moved from Postgres 11 client to Postgres 12 client