### PR TITLE
2022.02.03

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -20,7 +20,7 @@ env:
   DOCKER_BASE_IMAGE: python:3-alpine3.13
   DOCKER_TARGET_REPO: xirixiz/dsmr-reader-docker
   DOCKERFILE: Dockerfile
-  DOCKER_TARGET_RELEASE: 2022.02.02
+  DOCKER_TARGET_RELEASE: 2022.02.03
 
 jobs:
   ################################################
@@ -130,10 +130,10 @@ jobs:
         id: dsmr_version
         shell: bash
         run: |
-          # URL='https://api.github.com/repos/dsmrreader/dsmr-reader/releases/latest'
-          # VERSION=$(curl -SskLf "${URL}" | jq -r '.tag_name')
+          URL='https://api.github.com/repos/dsmrreader/dsmr-reader/releases/latest'
           # TODO: Add tag release support
-          VERSION="5.0.0"
+          VERSION=$(curl -SskLf "${URL}" | jq -r '.tag_name')
+          # VERSION="5.0.0"
           VERSION=${VERSION#"v"}
           echo "::set-output name=version::${VERSION}"
 
@@ -142,11 +142,11 @@ jobs:
           dsmr_version: ${{ steps.dsmr_version.outputs.version }}
         run: |
           mkdir -p tmp/app
-          curl -SskLf "https://github.com/dsmrreader/dsmr-reader/archive/refs/tags/v${dsmr_version}.tar.gz" | tar xvzf - --strip-components=1 -C tmp/app
-          # curl -SskLf "https://github.com/dsmrreader/dsmr-reader/archive/v${dsmr_version}.tar.gz" | tar xvzf - --strip-components=1 -C tmp/app
+          # TODO: Add tag release support
+          # curl -SskLf "https://github.com/dsmrreader/dsmr-reader/archive/refs/tags/v${dsmr_version}.tar.gz" | tar xvzf - --strip-components=1 -C tmp/app
+          curl -SskLf "https://github.com/dsmrreader/dsmr-reader/archive/v${dsmr_version}.tar.gz" | tar xvzf - --strip-components=1 -C tmp/app
           pushd tmp/app &&
           curl -SskLf "https://raw.githubusercontent.com/dsmrreader/dsmr-reader/v5/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py" -O &&
-          # curl -SskLf "https://raw.githubusercontent.com/dsmrreader/dsmr-reader/v4/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py" -O &&
           popd
 
       ################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,8 @@ RUN echo "**** configure nginx package ****" \
   && cp -f /app/dsmrreader/provisioning/nginx/dsmr-webinterface /etc/nginx/conf.d/dsmr-webinterface.conf
 
 # TODO: Improve healtcheck to respond on 200 only
-HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD curl -Lsf http://127.0.0.1/about -o /dev/null -w "HTTP_%{http_code}" || exit 1
+# TODO: Improve healtcheck so it's only valid for containers with the webinterface enabled
+# HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD curl -Lsf http://127.0.0.1/about -o /dev/null -w "HTTP_%{http_code}" || exit 1
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN echo "**** install runtime packages ****" \
   shadow \
   dpkg \
   curl \
+  jq \
   nginx \
   openssl \
   netcat-openbsd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN echo "**** configure nginx package ****" \
 
 # TODO: Improve healtcheck to respond on 200 only
 # TODO: Improve healtcheck so it's only valid for containers with the webinterface enabled
-# HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD curl -Lsf http://127.0.0.1/about -o /dev/null -w "HTTP_%{http_code}" || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD curl -Lsf http://127.0.0.1/about -o /dev/null -w "HTTP_%{http_code}" || exit 1
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -198,9 +198,12 @@ It's not possible to combine those settings!!!:
     -e DJANGO_DATABASE_USER=dsmrreader \
     -e DJANGO_DATABASE_PASSWORD=dsmrreader \
     -e VIRTUAL_HOST=localhost \
+    --no-healthcheck \
     --device /dev/ttyUSB0:/dev/ttyUSB0 \
     xirixiz/dsmr-reader-docker
   ```
+
+The ```--no-healthcheck``` argument should only be used when the containers function NOT presenting the DSMR Reader webinterface, for example the datalogger sender mode.
 
 ***
 #### Features

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ It's not possible to combine those settings!!!:
     xirixiz/dsmr-reader-docker
   ```
 
-The ```--no-healthcheck``` argument should only be used when the containers function NOT presenting the DSMR Reader webinterface, for example the datalogger sender mode.
+The ```--no-healthcheck``` argument should only be used when the containers function NOT presenting the DSMR Reader webinterface, for example the datalogger sender mode. By default this argument should not be used!
 
 ***
 #### Features

--- a/examples/docker-compose.example.yaml
+++ b/examples/docker-compose.example.yaml
@@ -44,6 +44,8 @@ services:
       - 7779:443
     devices:
       - "/dev/ttyUSB1:/dev/ttyUSB0"
+    # healthcheck:
+    #   disable: true
     healthcheck:
       test:
         [
@@ -59,6 +61,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+
+
 
 volumes:
   dsmrdb: null


### PR DESCRIPTION
- Switch back from tag to release.
- Added documentation to disable to healthcheck, for example for the sender container.