### PR TITLE
Fix pgsql user in compose health check

### DIFF
--- a/examples/docker-compose.example.yaml
+++ b/examples/docker-compose.example.yaml
@@ -16,7 +16,7 @@ services:
       - POSTGRES_PASSWORD=dsmrreader
       - POSTGRES_DB=dsmrreader
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: [ "CMD-SHELL", "pg_isready -U dsmrreader" ]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
This fixes the pgsql health check, so the log is not cluttered with messages like this:
```bash
dsmrdb  | 2022-03-24 19:57:40.193 CET [2117] FATAL:  role "postgres" does not exist
```