### PR TITLE
chore: upgrade to python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ ENV DSMR_VERSION=${DSMR_VERSION} \
     TERM="xterm" \
     PIP_NO_CACHE_DIR=1 \
 
-    # DSMR Reader-specifieke omgevingsvariabelen    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    # DSMR Reader-specifieke omgevingsvariabelen    
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     DJANGO_SECRET_KEY=dsmrreader \
     DJANGO_DATABASE_ENGINE=django.db.backends.postgresql \
     DJANGO_DATABASE_NAME=dsmrreader \


### PR DESCRIPTION
## Upgraded
- Python 3.11 =>3.12
- Alpine 3.21 => 3.22

## Changed
- Switch `pip` to `uv` as it is much faster
- Minor tweaks here and there

## Notes
- I initially wanted to upgrade to Python 3.13 but this didn't work because DSMR-Reader has dependency `psycopg2-binary==2.9.9` but Python 3.13 support is only available since `psycopg2-binary==2.9.10`. It doesn't feel clean to simplify overrule this version in the container, there is an open PR for this https://github.com/dsmrreader/dsmr-reader/pull/2044
- This might conflict with the changes in https://github.com/dennissiemensma/dsmr-reader-docker/pull/1